### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -54,7 +54,7 @@ class syntax_plugin_mathpublish extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         if ( $state == DOKU_LEXER_UNMATCHED ) {
             list($size, $math) = preg_split('/>/u', $match, 2);   // will split into size & math formulae
             if (!is_numeric($size)) $size = 12; // default size in pixels
@@ -88,7 +88,7 @@ class syntax_plugin_mathpublish extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if(!$data)           return; // skip rendering for the enter and exit patterns #FIXME
         if(!$this->enable)   return;
         if($mode != 'xhtml') return;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
