### PR TITLE
Minor adjustments for PHP7.0. See #9.

### DIFF
--- a/phpmathpublisher/expression.php
+++ b/phpmathpublisher/expression.php
@@ -307,7 +307,7 @@ class PMP_expression{
      * @return unknown
      */
     protected function est_nombre($str){
-        return ereg("^[0-9]", $str);
+        return preg_match('/^[0-9]/', $str);
     }
 
     /**
@@ -607,7 +607,7 @@ class PMP_expression{
         $texte = stripslashes($texte);
         if(isset($this->fontesmath[$texte]))
             $font = $this->dirfonts."/".$this->fontesmath[$texte].".ttf";
-        elseif(ereg("[a-zA-Z]", $texte))
+        elseif(preg_match('/[a-zA-Z]/', $texte))
             $font = $this->dirfonts."/FreeSerifItalic.ttf";
         else
             $font = $this->dirfonts."/FreeSerif.ttf";

--- a/phpmathpublisher/mathpublisher.php
+++ b/phpmathpublisher/mathpublisher.php
@@ -49,7 +49,8 @@ class phpmathpublisher{
         $handle = opendir($this->dirimg);
         while($fi = readdir($handle)){
             $info = pathinfo($fi);
-            if($fi != "." && $fi != ".." && $info["extension"] == "png" && ereg("^math", $fi)){
+            //if($fi != "." && $fi != ".." && $info["extension"] == "png" && ereg("^math", $fi)){
+            if($fi != "." && $fi != ".." && $info["extension"] == "png" && preg_match('/^math/', $fi)){
                 list($math, $v, $name) = explode("_", $fi);
                 if($name == $n){
                     $ret = $v;
@@ -165,7 +166,7 @@ class phpmathpublisher{
         for($i = 0; $i < count($t); $i++){
             if(is_array($t[$i]))
                 $t[$i] = $t[$i][1];
-            if(ereg("formula", $t[$i])){
+            if(strpos($t[$i], 'formula')!==false){
                 $d = $i + 2;
                 break;
             }


### PR DESCRIPTION
Partly fixes issue #9.
Anyway the rendering result is not as expected.

E.g. the rendering of example

```
<m>S(f)(t)=a_{0}+sum{n=1}{+infty}{a_{n} cos(n omega t)+b_{n} sin(n omega t)}</m>
```

leads to the text **<?php formula =** preceding the rendered formula.

So the fix is not complete but I will not put more time in it.
